### PR TITLE
Wroking with python3

### DIFF
--- a/email_html/templatetags/email_html.py
+++ b/email_html/templatetags/email_html.py
@@ -2,6 +2,11 @@ from django import template
 from subprocess import Popen, PIPE
 from bs4 import BeautifulSoup
 
+try:
+    unicode_type = unicode
+except NameError:
+    unicode_type = str
+
 register = template.Library()
 
 @register.filter
@@ -25,7 +30,7 @@ def extract_urllinks(value, template='%(text)s (%(url)s)'):
     '''
     html = BeautifulSoup(value)
     for link in html.findAll('a'):
-        text = ''.join(map(unicode, link.contents)).strip()
+        text = ''.join(map(unicode_type, link.contents)).strip()
         if link.get('href') and link.get('href') != text:
             result = template % {
                 'text': text,

--- a/email_html/templatetags/email_html.py
+++ b/email_html/templatetags/email_html.py
@@ -17,7 +17,7 @@ def html2text(value):
     """
     try:
         cmd = "w3m -dump -T text/html -O utf-8"
-        proc = Popen(cmd, shell = True, stdin = PIPE, stdout = PIPE)
+        proc = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE, universal_newlines=True)
         return proc.communicate(str(value))[0]
     except OSError:
         # something bad happened, so just return the input


### PR DESCRIPTION
Fixes two problems with the difference between strings and bytes/unicode in python2 vs python3.
As the unicode type is no longer defined in python3 the code as it was would not run on python3. With this little change it works in both python2 and python3.
Also communicate expects bytes now. The added universal_newlines to Popen makes it so that communicate always expects a newline separated string.